### PR TITLE
Image bug fix

### DIFF
--- a/MMM-Cocktails.js
+++ b/MMM-Cocktails.js
@@ -62,7 +62,7 @@ var cocktails = this.cocktails;
 
            var drinkLogo = document.createElement("div");
            var drinkIcon = document.createElement("img");
-           drinkIcon.src = "http://"+cocktails.strDrinkThumb;
+           drinkIcon.src = cocktails.strDrinkThumb;
            drinkIcon.classList.add("post-thumb");
            drinkLogo.appendChild(drinkIcon);
            top.appendChild(drinkLogo);


### PR DESCRIPTION
The cocktail database API has updated so that the URL passed with the image is now complete and does not require the addition of the http:// prefix